### PR TITLE
Switch to a bi-polar signal by default

### DIFF
--- a/Source/MetasoundBranches/Private/MetasoundDustNode.cpp
+++ b/Source/MetasoundBranches/Private/MetasoundDustNode.cpp
@@ -34,6 +34,7 @@ namespace Metasound
             , InputDensityOffset(InDensityOffset)
             , OutputImpulse(FAudioBufferWriteRef::CreateNew(InDensity->Num()))
             , RNGStream(InitialSeed()) // Initialize with a seed
+            , SignalIsPositive(true)
         {
         }
 
@@ -144,7 +145,8 @@ namespace Metasound
                 // Compare to threshold
                 if (RandomValue > Threshold)
                 {
-                    OutputDataPtr[i] = 1.0f; // Impulse
+                    OutputDataPtr[i] = SignalIsPositive ? 1.0f : -1.0f; // Impulse
+                    SignalIsPositive = !SignalIsPositive; // Toggle polarity
                 }
                 else
                 {
@@ -164,6 +166,9 @@ namespace Metasound
 
         // Random number generator
         FRandomStream RNGStream;
+        
+        // Toggle flag for polarity
+        bool SignalIsPositive;
 
         // Generate an initial seed for FRandomStream
         static int32 InitialSeed()


### PR DESCRIPTION
More suitable for cases when audio is to be used directly (we can chain with abs~ for control purposes). 

Working on a bool control for this in the branch, but merging for now.